### PR TITLE
Fix misspelled phrase

### DIFF
--- a/CCIP/Supporting Files/OPass/zh-Hant.lproj/Localizable.strings
+++ b/CCIP/Supporting Files/OPass/zh-Hant.lproj/Localizable.strings
@@ -48,9 +48,9 @@
 "Addition" = "其他";
 "IRC" = "IRC 頻道";
 "Puzzle" = "開源巔峰挑戰賽";
-"Ticket" = "我的票卷";
-"TicketNotice" = "請妥善保管您的票卷，僅提供此票卷給我們的工作人員或您參與攤位活動的工作人員使用";
-"TicketNonExistNotice" = "您的票卷尚未登錄進 OPass，請登錄後再使用此功能！";
+"Ticket" = "我的票券";
+"TicketNotice" = "請妥善保管您的票券，僅提供此票券給我們的工作人員或您參與攤位活動的工作人員使用";
+"TicketNonExistNotice" = "您的票券尚未登錄進 OPass，請登錄後再使用此功能！";
 "Telegram" = "Telegram 群組";
 "MapsWeb" = "場內地圖";
 "Maps" = "場內地圖";


### PR DESCRIPTION
Should be 票券 instead 票卷. (・ω・)